### PR TITLE
Serving up static files

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,9 +3,7 @@ const app = express();
 
 const https = require('https');
 
-app.get('/', function(req, res){
-  res.sendFile('index.html', { root: './app'});
-});
+app.use('/', express.static('app'))
 
 app.listen(8000, function(){
   console.log('Really Now listening on port 8000')
@@ -21,7 +19,7 @@ app.get('/input', function(req, res){
     radius: 2,
   }
   let requestURL = `https://search.onboard-apis.com/propertyapi/v1.0.0/Resource/Package?${parameter}`
-  
+
   https.get(requestURL, function(res){
     console.log(res);
   });


### PR DESCRIPTION
Hello Laurie!

@David-Shibley mentioned to me this morning that for reasons unknown, your app wasn't serving up your .css file, and instead just returns a 404, and asked if I had any ideas why.  I have a hard time leaving questions like that unanswered, so I took a look.

If you want to figure it out on your own, don't read the code change, but I'll talk it out here.  I hope you don't mind me butting in, and I certainly won't be offended if you want to tackle this on your own.

# Thinking...

In its present state, your app is configured to serve up the `index.html` whenever there is a GET request to the `/` path.  And the index.html is able to correctly request the CDN'ed jquery, bootstrap, etc.  It also requests your `index.css`.

The way that you are requesting `index.css` in `index.html` is exactly correct.  You are saying "gimme the stylesheet located at /index.css".

So, then... why isn't the server picking it up?

Let's think again about how `index.html` is getting served.  When you navigate to `localhost:8000`, what happens?  The server sees a GET request at `/`, and looks at its routing table.  There is a match for _exactly_ that path, and it returns the `index.html` file located in the `app` folder.

What happens if you navigate to `localhost:8000/index.html`?

(Give it a shot, I'll wait a minute.)

It didn't work, did it?

(If it _did_ work, I'm a little confused.)

The server sees a GET request for `/index.html`, and there is no route for that path, so it automagically returns you a 404.  So, there's a clue... if it can't find the figure out what to do when you request `/index.html`, it probably can't figure out `/index.css` for the same reason.

# One possible answer

So, there are a couple of things you can do at this point.  Just like you have a very specific route for `/`, you can probably set up a very specific route for `/index.css`.  In fact, if I was writing a very, very hardened web service, I might do that.  (In that case, I might want my app to serve up only _exactly_ the files that I very deliberately tell it to, and nothing else that might accidentally be lying around.)  But, that's kind of a pain in the butt, because every time that you add a new resource, you have to tell the server how to serve the file.

# The answer I came up with

There is an easier way.  Express has a feature for [serving up static files](https://expressjs.com/en/starter/static-files.html).  You can tell it to serve up all the files in a directory, with the same path.  So, looking at your app, you have some static files in your `app` directory, and you want them to all be served from the `/` path.  That's what the change in this PR does; it handles any request at the `/` by looking for that resource in the `app` directory.

# But wait, there's more!

Alright, but there's one more riddle here.  If the browser is navigating to `localhost:8000/`, there isn't any specific resource path getting requested -- how does the server know to return `index.html`?

Well, I wasn't able to find the exact piece of documentation, but it's very common for web servers to try a couple of default paths if there isn't anything exactly at `/`, and `/index.html` is one of them.  So Express is trying to be helpful and give you a little something for free.  I don't know if it will automatically look for an index file in `/foo/bar` (for example) if you try navigating there, or if it's just at the root level.

# What next?

So, now your app is set up to serve static files from `/`.  But what if you want to be able to GET something to a `/addresses` route?  Won't the server try to find some static file named `addresses`?  Well, yes, but there's a way around that.

The order in which you set up routes in Express is very important.  In fact, the greater the specificity of your route, the sooner you should set it up.  The `/` route is kind of a catch-all, but `/addresses` is more specific, so you will put your handler in the code for that route in before the generic route.  

Examples...
`http://localhost:8000/index.css`
1) Does this match `/addresses`?  No.  OK, next!
2) Does this match `/`?  Sufficiently, yes.  Find the `index.css` static file and serve it up.  Done.

`http://localhost:8000/addresses?city=denver`
1) Does this match `/addresses`?  Yes.  OK, take that router's action.  Done.

`http://localhost:8000/foo.css`
1) Does this match `/addresses`?  No. OK, next!
2) Does this match `/`?  Sufficiently, yes.  Find the `foo.css` static file and serve it up.  Oh-oh, don't have that file.
3) Serve up that 404.

# Errata

(Also, please ignore the changes to lines 24 and 30; my editor is picky about whitespace and keeps making unnecessary edits.)